### PR TITLE
added Solaris support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ The module installs and configures OpenAFS.
 This module provides OS default values for these OSfamilies:
 
  * RedHat
+ * Solaris
  * Suse
 
 For other OSfamilies support, please specify all parameters which defaults to 'USE_DEFAULTS'.
@@ -134,7 +135,7 @@ config_client_args
 ------------------
 AFSD_ARGS / parameters to be passed to AFS daemon while starting.
 Since 1.6.x the afs-client has integrated auto-tuning. So specifying more options for tuning should only be applied after monitoring the system.
-candidates for tuning: -stat, -volumes
+Candidates for tuning: -stat, -volumes
 
 - *Default*: '-dynroot -afsdb -daemons 6 -volumes 1000'
 
@@ -201,8 +202,50 @@ afs::symlinks:
 </pre>
 
 
-packages
---------
-Array of needed OpenAFS packages
+package_adminfile
+-----------------
+Solaris specific: string with adminfile.
+
+- *Default*: undef
+
+
+package_name
+------------
+Array of needed OpenAFS packages.
 
 - *Default*: 'USE_DEFAULTS', based on OS platform
+
+
+package_source
+--------------
+Solaris specific: string with package source.
+
+- *Default*: undef
+
+
+service_provider
+----------------
+Solaris specific (mostly): string with provider for service.
+Should be undef for Linux and 'init' for Solaris.
+
+- *Default*: undef
+
+
+# Solaris specific #
+For usage on Solaris, you will need to define these variables:
+
+$package_adminfile, $package_source and $service_provider
+
+If you want to create a cron job, please set $afs_cron_job_interval to 'specific' and choose your values for $afs_cron_job_hour and $afs_cron_job_minute.
+
+Hiera example:
+<pre>
+afs::afs_cron_job_interval: 'specific'
+afs::afs_cron_job_content:  '[ -x /afs_maintenance.sh ] && /afs_maintenance.sh'
+afs::afs_cron_job_hour:     '2'
+afs::afs_cron_job_minute:   '42'
+
+afs::package_adminfile:     '/path/to/adminfile/noask'
+afs::package_source:        '/path/to/package/openafs-x.x.x-x-Sol10'
+afs::service_provider:      'init'
+</pre>

--- a/files/openafs-client-Solaris
+++ b/files/openafs-client-Solaris
@@ -1,0 +1,203 @@
+#!/bin/sh
+#
+# Copyright (c) 2014 AFS-Core Ericsson
+# Version v1.0, 2014-03-14 by eralbru
+#
+# openafs-client  Start/Stop the OpenAFS Client
+#
+#
+
+DAEMON="OpenAFS Client"
+DAEMON_BIN=/usr/vice/etc/afsd
+CONFIG=/usr/vice/etc/sysconfig
+AFSDOPT=$CONFIG/openafs-client
+AFS=/afs
+SUIDCELLS=/usr/vice/etc/SuidCells
+
+[ -f $AFSDOPT ] && . $AFSDOPT
+
+# Set the minimum required options for afsd if no options set in $AFSDOPT
+AFSD_ARGS=${AFSD_ARGS:-"-dynroot -afsdb"}
+
+suid() {
+  if [ -f $SUIDCELLS ]; then
+    for CELLS in `cat $SUIDCELLS | grep -v '^#'`; do
+      echo "Setting $CELLS suid"
+      /usr/afs/bin/fs setcell -cell $CELLS -suid
+    done
+  fi
+}
+
+# Need the commands ps, awk, kill, sleep
+PATH=${PATH}${PATH:+:}/sbin:/bin:/usr/bin
+
+killproc() {            # kill the named process(es)
+      awkfield2='$2'
+        pid=`ps -ef | awk "/$1/ && ! /awk/ {print $awkfield2}"`
+        [ "$pid" != "" ] && kill -KILL $pid
+}
+
+case $1 in
+'start')
+
+# Not starting afsd on containers (non global zone)
+if uname -v | grep Virtual >/dev/null || { zonename; } 2>/dev/null | fgrep -vx global >/dev/null; then
+  echo "Solaris Non-Global Zone: afsd will not start and is not needed !"
+	exit
+fi
+  
+#
+# Make sure afs exists in /etc/name_to_sysnum
+#
+if grep -s "afs" /etc/name_to_sysnum > /dev/null; then
+    echo "Entry for afs already exists in /etc/name_to_sysnum"
+else
+    echo "Creating entry for afs in /etc/name_to_sysnum"
+    cp /etc/name_to_sysnum /etc/name_to_sysnum.orig
+    sed '/nfs/i\
+afs			65' /etc/name_to_sysnum > /tmp/name_to_sysnum
+    mv /tmp/name_to_sysnum /etc/name_to_sysnum
+    echo "Reboot the system now for new /etc/name_to_sysnum to take effect"
+    #reboot
+fi
+
+## Check to see that /bin/isalist exists and is executable
+if [ ! -x /bin/isalist ] ;then
+      echo "/bin/isalist not executable"
+      exit 1;
+fi
+
+## Determine if we are running the 64 bit OS
+## If sparcv9 then the location of the afs and nfs extensions differ
+
+case `/bin/isalist` in
+    *amd64* )
+              nfssrv=/kernel/misc/amd64/nfssrv
+              afs=/kernel/fs/amd64/afs ;;
+    *sparcv9* )
+              nfssrv=/kernel/misc/sparcv9/nfssrv
+              afs=/kernel/fs/sparcv9/afs ;;
+          * )
+              nfssrv=/kernel/misc/nfssrv
+              afs=/kernel/fs/afs ;;
+esac
+
+
+#
+# Load kernel extensions
+#
+# nfssrv has to be loaded first
+
+
+if [ -f $nfssrv ]; then
+      echo "Loading NFS server kernel extensions"
+      modload $nfssrv
+else
+      echo "$nfssrv does not exist. Skipping AFS startup."
+      exit 1
+fi
+
+## Load AFS kernel extensions
+
+if [ -f $afs ]; then
+      echo "Loading AFS kernel extensions"
+      modload $afs
+else
+      echo "$afs does not exist. Skipping AFS startup."
+      exit 1
+fi
+
+#
+# Check that all of the client configuration files exist
+#
+
+for file in /usr/vice/etc/afsd /usr/vice/etc/cacheinfo \
+          /usr/vice/etc/ThisCell /usr/vice/etc/CellServDB
+do
+      if [ ! -f ${file} ]; then
+              echo "${file} does not exist. Not starting AFS client."
+              exit 1
+      fi
+done
+
+#
+# Check that the root directory for AFS (/afs) 
+# and the cache directory (/usr/vice/cache) both exist
+#
+
+for dir in `awk -F: '{print $1, $2}' /usr/vice/etc/cacheinfo`
+do
+      if [ ! -d ${dir} ]; then
+              echo "${dir} does not exist. Not starting AFS client."
+              exit 2
+      fi
+done
+
+echo "Starting $DAEMON "
+if ps -ef | grep [/]usr/vice/etc/afsd >/dev/null; then
+  echo " -> already running"
+else
+  $DAEMON_BIN $AFSD_ARGS
+  RETVAL=$?
+  if [ $RETVAL -eq 0 ]; then
+    suid
+  fi
+fi
+
+  echo ;;
+
+'stop')
+
+#
+# Stop the AFS client
+# Note that the afsd processes cannot be killed
+#
+
+echo "Stopping openafs-client: "
+if ps -ef | grep [/]usr/vice/etc/afsd > /dev/null; then
+  umount $AFS
+  RETVAL=$?
+  echo
+  if [ $RETVAL -eq 0 ] ; then
+    MODID=`modinfo -c | awk '/afs/ {print $1}'`
+    modunload -i $MODID
+    RETVAL=$?
+    if [ $RETVAL -eq 0 ] ; then
+      echo "Kernel module afs unloaded "
+    else
+      echo "Problems to unload kernel module "
+    fi
+  fi
+else
+  echo " -> $DAEMON not running"
+fi
+echo ;;
+
+'check')
+#
+# Check the running AFS client
+#
+
+echo "Checking openafs-client: "
+if uname -v | grep Virtual >/dev/null || { zonename; } 2>/dev/null | fgrep -vx global >/dev/null; then
+	if [ -f /afs/sunrise.ericsson.se/afsadm/bin/afs_site_health_check.sh ]; then
+		/afs/sunrise.ericsson.se/afsadm/bin/afs_site_health_check.sh
+	else
+		echo "Check-script not available: /afs/sunrise.ericsson.se/afsadm/bin/afs_site_health_check.sh"
+	fi
+else
+  if ps -ef | grep [/]usr/vice/etc/afsd > /dev/null; then
+  	if [ -f /afs/sunrise.ericsson.se/afsadm/bin/afs_site_health_check.sh ]; then
+  		/afs/sunrise.ericsson.se/afsadm/bin/afs_site_health_check.sh
+  	else
+  		echo "Check-script not available: /afs/sunrise.ericsson.se/afsadm/bin/afs_site_health_check.sh"
+  	fi
+  else
+  	echo "Cannot check openafs-client: not running"
+  fi
+fi
+	echo ;;
+
+*)    echo "Usage: $0 {start|stop|check}"
+      exit 1;;
+esac


### PR DESCRIPTION
This PR adds support for Solaris and closes issue https://github.com/Phil-Friderici/puppet-module-afs/issues/1

ACHTUNG!!!:
The variable which contains the package names was renamed from $packages to $package_name.
You need to adjust the variable name only if you have specified a different value for it.
If you were using the OS defaults ('USE_DEFAULTS') there is nothing to do for you :)
