### PR TITLE
Added fact for openafs version check

### DIFF
--- a/lib/facter/afs_version.rb
+++ b/lib/facter/afs_version.rb
@@ -1,0 +1,11 @@
+# afs_version.rb
+
+Facter.add("afs_version") do
+  setcode do
+    test_exists = "rpm -q openafs 2>&1 >/dev/null ; echo $?"
+    if Facter::Util::Resolution.exec(test_exists) == '0'
+      cmd = "rpm -q --queryformat='%{VERSION}' openafs"
+      response = Facter::Util::Resolution.exec(cmd)
+    end
+  end
+end


### PR DESCRIPTION
The fact checks if openafs package is installed and gets the version of the package to a fact called afs_version.

The fact only works on rpm based distributions.
